### PR TITLE
doc: more clarity for GetBlockRange description

### DIFF
--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -211,9 +211,10 @@ service CompactTxStreamer {
     // `PoolType::TRANSPARENT` member of the `poolTypes` argument.
     rpc GetBlockNullifiers(BlockID) returns (CompactBlock) {}
 
-    // Return a list of consecutive compact blocks in the specified range.
+    // Return a list of consecutive compact blocks in the specified range,
+    // which is inclusive of `range.end`.
     //
-    // If range.start <= range.end, blocks are returned increasing height order; 
+    // If `range.start` < `range.end`, blocks are returned increasing height order;
     // otherwise blocks are returned in decreasing height order.
     rpc GetBlockRange(BlockRange) returns (stream CompactBlock) {}
 


### PR DESCRIPTION
This is a follow-up to #5 - document that the range is inclusive of `start.end`. See [comment in #5](https://github.com/zcash/lightwallet-protocol/pull/5#discussion_r2508388804)