### PR TITLE
add next upgrade info to LightdInfo structure (GetLightdInfo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this library adheres to Rust's notion of
 - `compact_formats.CompactTxIn`
 - `compact_formats.TxOut`
 - `service.PoolType`
+- `lightdinfo.upgradeName`
+- `lightdinfo.upgradeHeight`
 
 ### Changed
 - The `compact_formats.CompactTx` type has added fields `vin` and `vout`,
@@ -24,6 +26,8 @@ and this library adheres to Rust's notion of
 - The `hash` field of `compact_formats.CompactTx` has been renamed to `txid`.
   This is a serialization-compatible clarification, as the index of this field
   in the .proto type does not change.
+- The `GetLightdInfo` RPC is modified to return the name and height of the
+  next pending protocol upgrade, if there is one.
 
 ### Deprecated
 - `service.CompactTxStreamer`:

--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -107,6 +107,8 @@ message LightdInfo {
     string zcashdBuild = 13;            // example: "v4.1.1-877212414"
     string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
     string donationAddress = 15;        // Zcash donation UA address
+    string upgradeName = 16;            // name of next pending network upgrade, empty if none scheduled
+    uint64 upgradeHeight = 17;          // height of next pending upgrade, zero if none is scheduled
 }
 
 // TransparentAddressBlockFilter restricts the results of the GRPC methods that


### PR DESCRIPTION
Enhance the GetLightdInfo RPC to return these fields:

- upgradeName (string)
- upgradeHeight (uint64)

These will be populated if and when there is a scheduled or pending zcash protocol upgrade (else they will be the empty string and zero, respectively). See lightwalletd PR 529.

This is a backward-compatible change.