### PR TITLE
2026 03 doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## Unreleased
 
+## [v0.4.1] - 2026-02-20
+
+### Added
+- `README.md`
+
+### Changed
+- Designate `GetBlockNullifiers` and `GetBlockRangeNullifiers` as deprecated
+- Document `GetBlock` transparent data behavior
+- Clarify documentation of `GetBlockNullifiers` and `GetBlockRangeNullifiers`
+
 ## [v0.4.0] - 2025-12-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We assume YourProject is a git repository. Begin with a clean working tree.
 any changes you're making to your project should be in separate commits.)
 
 You can install the `tree` command using your OS package manager of choice (although is not necessary).
+(Replace the version tag with the appropriate one, usually the latest.)
 ```
 $ cd YourProject
 $ git subtree --prefix=lightwallet-protocol/ pull git@github.com:zcash/lightwallet-protocol.git v0.4.0 --squash
@@ -40,7 +41,7 @@ $ tree .
 ```
 ## Current implementations
 ### Servers
-- [Lightwalletd (Go)](https://github.com/zcash/lightwalletd/) 
+- [Lightwalletd (Go)](https://github.com/zcash/lightwalletd/)
 - [Zaino (Rust)](https://github.com/zingolabs/zaino)
 ### Clients
 #### CLI and Dev Tooling
@@ -48,7 +49,7 @@ $ tree .
 - [Zcash dev-tool (Rust)](https://github.com/zcash/zcash-devtool)
 - [zcash_client_backend Rust crate](https://docs.rs/zcash_client_backend/latest/zcash_client_backend/)
 #### Light Wallets
-- Zashi [[iOS](https://github.com/Electric-Coin-Company/zcash-swift-wallet-sdk/) | [Android](https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/)] 
+- Zashi [[iOS](https://github.com/Electric-Coin-Company/zcash-swift-wallet-sdk/) | [Android](https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/)]
 - [Ywallet (Dart/Flutter)](https://github.com/hhanh00/zwallet)
 
 ## Discussing and developing the Zcash Light Client Protocol


### PR DESCRIPTION
Add tag v0.4.1, and some very minor fixups.

This release is functionally identical to v0.4.0 and consists only of minor documentation improvements. 

Between 0.4.0 and 0.4.1, a new field, `fullHeader`, was added to `service.proto: BlockID`, but that change was reverted, so no functional changes since v0.4.0.