### PR TITLE
Remove `protoVersion` field from `CompactBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## Unreleased
 
+### Removed
+- `compact_formats.CompactBlock.protoVersion` has been removed. The field
+  number `1` and name `protoVersion` are now reserved. See
+  [#25](https://github.com/zcash/lightwallet-protocol/issues/25).
+
 ## [v0.4.1] - 2026-02-20
 
 ### Added

--- a/walletrpc/compact_formats.proto
+++ b/walletrpc/compact_formats.proto
@@ -29,7 +29,10 @@ message ChainMetadata {
 // parameters, although it is likely that such flexibility will only be provided via 
 // newly-added service methods, not via existing APIs.
 message CompactBlock {
-    uint32 protoVersion = 1;         // the version of this wire format, for storage
+    // Field 1 (`protoVersion`) was removed; see
+    // https://github.com/zcash/lightwallet-protocol/issues/25
+    reserved 1;
+    reserved "protoVersion";
     uint64 height = 2;               // the height of this block
     bytes hash = 3;                  // if present, the ID (hash) of this block
     bytes prevHash = 4;              // if present, the ID (hash) of this block's predecessor


### PR DESCRIPTION
## Summary
- Remove the `protoVersion` field from `compact_formats.CompactBlock` and reserve field number `1` and the name `protoVersion` to prevent reuse.
- Update `CHANGELOG.md` with a `Removed` entry under `Unreleased`.

The field was unused by lightwalletd and was being repurposed inconsistently by other implementations (e.g. Zaino used it as a block version).

Closes #25

## Test plan
- [ ] Verify `.proto` files still parse with `protoc`
- [ ] Confirm no other references to `protoVersion` remain in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)