### PR TITLE
Apply Ironwood protobuf scanning updates

### DIFF
--- a/walletrpc/compact_formats.proto
+++ b/walletrpc/compact_formats.proto
@@ -14,6 +14,7 @@ option swift_prefix = "";
 message ChainMetadata {
     uint32 saplingCommitmentTreeSize = 1; // the size of the Sapling note commitment tree as of the end of this block
     uint32 orchardCommitmentTreeSize = 2; // the size of the Orchard note commitment tree as of the end of this block
+    uint32 ironwoodCommitmentTreeSize = 3; // the size of the Ironwood note commitment tree as of the end of this block
 }
 
 // A compact representation of a Zcash block.
@@ -63,12 +64,14 @@ message CompactTx {
     // stateless server and a transaction with transparent inputs, this will be
     // unset because the calculation requires reference to prior transactions.
     // If there are no transparent inputs, the fee will be calculable as:
-    //    valueBalanceSapling + valueBalanceOrchard + sum(vPubNew) - sum(vPubOld) - sum(tOut)
+    //    valueBalanceSapling + valueBalanceOrchard + valueBalanceIronwood
+    //    + sum(vPubNew) - sum(vPubOld) - sum(tOut)
     uint32 fee = 3;
 
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
+    repeated CompactOrchardAction ironwoodActions = 9;
 
     // `CompactTxIn` values corresponding to the `vin` entries of the full transaction.
     //

--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -14,6 +14,7 @@ enum PoolType {
     TRANSPARENT = 1;
     SAPLING = 2;
     ORCHARD = 3;
+    IRONWOOD = 4;
 }
 
 // A BlockID message contains identifiers to select a block: a height or a
@@ -29,9 +30,9 @@ message BlockID {
 // Both BlockIDs must be heights; specification by hash is not yet supported.
 //
 // If no pool types are specified, the server should default to the legacy
-// behavior of returning only data relevant to the shielded (Sapling and
-// Orchard) pools; otherwise, the server should prune `CompactBlock`s returned
-// to include only data relevant to the requested pool types. Clients MUST 
+// behavior of returning only data relevant to the shielded (Sapling, Orchard,
+// and Ironwood) pools; otherwise, the server should prune `CompactBlock`s
+// returned to include only data relevant to the requested pool types. Clients MUST
 // verify that the version of the server they are connected to are capable
 // of returning pruned and/or transparent data before setting `poolTypes`
 // to a non-empty value.
@@ -169,7 +170,7 @@ message GetMempoolTxRequest {
     // The server must prune `CompactTx`s returned to include only data
     // relevant to the requested pool types. If no pool types are specified,
     // the server should default to the legacy behavior of returning only data
-    // relevant to the shielded (Sapling and Orchard) pools.
+    // relevant to the shielded (Sapling, Orchard, and Ironwood) pools.
     repeated PoolType poolTypes = 3;
 }
 
@@ -181,11 +182,13 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood commitment tree state
 }
 
 enum ShieldedProtocol {
     sapling = 0;
     orchard = 1;
+    ironwood = 2;
 }
 
 message GetSubtreeRootsArg {
@@ -227,9 +230,9 @@ service CompactTxStreamer {
     // The returned `CompactBlock` includes transaction data for all value
     // pools, including transparent inputs (`vin`) and outputs (`vout`). This
     // differs from `GetBlockRange`, which supports filtering by pool type and
-    // defaults to returning only shielded (Sapling and Orchard) data. Clients
-    // that require only data for specific pools should use `GetBlockRange`
-    // with the appropriate `poolTypes` set.
+    // defaults to returning only shielded (Sapling, Orchard, and Ironwood)
+    // data. Clients that require only data for specific pools should use
+    // `GetBlockRange` with the appropriate `poolTypes` set.
     //
     // Note: the single null-outpoint input for coinbase transactions is
     // omitted from the `vin` field of the corresponding `CompactTx`. See the
@@ -237,9 +240,10 @@ service CompactTxStreamer {
     rpc GetBlock(BlockID) returns (CompactBlock) {}
 
     // Return a compact block containing only nullifier information for the
-    // shielded pools (Sapling spend nullifiers and Orchard action nullifiers).
-    // Transparent transaction data, Sapling outputs, full Orchard action data,
-    // and commitment tree sizes are not included.
+    // shielded pools (Sapling spend nullifiers, Orchard action nullifiers, and
+    // Ironwood action nullifiers). Transparent transaction data, Sapling
+    // outputs, full Orchard/Ironwood action data, and commitment tree sizes are
+    // not included.
     //
     // Note: this method is deprecated; use `GetBlockRange` with the
     // appropriate `poolTypes` instead.
@@ -256,9 +260,10 @@ service CompactTxStreamer {
 
     // Return a stream of compact blocks for the specified range, where each
     // block contains only nullifier information for the shielded pools
-    // (Sapling spend nullifiers and Orchard action nullifiers). Transparent
-    // transaction data, Sapling outputs, full Orchard action data, and
-    // commitment tree sizes are not included. Implementations MUST ignore any
+    // (Sapling spend nullifiers, Orchard action nullifiers, and Ironwood action
+    // nullifiers). Transparent transaction data, Sapling outputs, full
+    // Orchard/Ironwood action data, and commitment tree sizes are not included.
+    // Implementations MUST ignore any
     // `PoolType::TRANSPARENT` member of the `poolTypes` field of the request.
     //
     // Note: this method is deprecated; use `GetBlockRange` with the
@@ -312,7 +317,7 @@ service CompactTxStreamer {
     rpc GetLatestTreeState(Empty) returns (TreeState) {}
 
     // Returns a stream of information about roots of subtrees of the note commitment tree
-    // for the specified shielded protocol (Sapling or Orchard).
+    // for the specified shielded protocol (Sapling, Orchard, or Ironwood).
     rpc GetSubtreeRoots(GetSubtreeRootsArg) returns (stream SubtreeRoot) {}
 
     rpc GetAddressUtxos(GetAddressUtxosArg) returns (GetAddressUtxosReplyList) {}


### PR DESCRIPTION
## Summary
- add Ironwood pool/protocol enum values and tree metadata fields
- add Ironwood compact block/transaction fields from librustzcash
- update shielded-pool comments to include Ironwood

## Source
Taken from librustzcash commit ironwood-integration branch, for steel-threading full stack integration.

## Validation
- git diff --check
- searched walletrpc for stale Sapling/Orchard-only terminology